### PR TITLE
处理 Janome 等复杂注音机制的架构问题

### DIFF
--- a/backend/app/lyrics/numeric_reading.py
+++ b/backend/app/lyrics/numeric_reading.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Sequence
+
+
+_ASCII_DIGITS = re.compile(r"[0-9]+")
+_DIGIT_READINGS = (
+    "ぜろ",
+    "いち",
+    "に",
+    "さん",
+    "よん",
+    "ご",
+    "ろく",
+    "なな",
+    "はち",
+    "きゅう",
+)
+_LARGE_UNITS = ("", "まん", "おく", "ちょう")
+_COUNTERS = frozenset(("人", "分", "泊", "つ", "丁目", "月", "日", "時", "時半"))
+_JAPANESE_TEXT = re.compile(r"[\u3040-\u30ff\u3400-\u9fff]")
+
+
+@dataclass(frozen=True)
+class NumericReadingPart:
+    surface: str
+    reading: str
+
+
+@dataclass(frozen=True)
+class NumericReadingSpan:
+    consumed_items: int
+    parts: tuple[NumericReadingPart, ...]
+
+
+def _four_digit_reading(value: int) -> str:
+    if not 0 <= value <= 9999:
+        raise ValueError("four digit group is out of range")
+    if value == 0:
+        return ""
+
+    thousands, remainder = divmod(value, 1000)
+    hundreds, remainder = divmod(remainder, 100)
+    tens, ones = divmod(remainder, 10)
+    parts: list[str] = []
+
+    if thousands:
+        parts.append(
+            {1: "せん", 3: "さんぜん", 8: "はっせん"}.get(
+                thousands,
+                _DIGIT_READINGS[thousands] + "せん",
+            )
+        )
+    if hundreds:
+        parts.append(
+            {
+                1: "ひゃく",
+                3: "さんびゃく",
+                6: "ろっぴゃく",
+                8: "はっぴゃく",
+            }.get(hundreds, _DIGIT_READINGS[hundreds] + "ひゃく")
+        )
+    if tens:
+        parts.append("じゅう" if tens == 1 else _DIGIT_READINGS[tens] + "じゅう")
+    if ones:
+        parts.append(_DIGIT_READINGS[ones])
+    return "".join(parts)
+
+
+def integer_reading(digits: str) -> str:
+    if _ASCII_DIGITS.fullmatch(digits) is None:
+        raise ValueError("integer reading requires ASCII digits")
+    normalized = digits.lstrip("0") or "0"
+    if normalized == "0":
+        return "ぜろ"
+    if len(normalized) > 16:
+        raise ValueError("integer reading supports values below 10^16")
+
+    groups: list[int] = []
+    while normalized:
+        groups.append(int(normalized[-4:]))
+        normalized = normalized[:-4]
+
+    parts: list[str] = []
+    for group_index in range(len(groups) - 1, -1, -1):
+        value = groups[group_index]
+        if value == 0:
+            continue
+        group_reading = _four_digit_reading(value)
+        unit = _LARGE_UNITS[group_index]
+        if unit == "ちょう" and group_reading.endswith("いち"):
+            group_reading = group_reading[:-2] + "いっ"
+        parts.append(group_reading)
+        parts.append(unit)
+    return "".join(parts)
+
+
+def _replace_ending(reading: str, old: str, new: str) -> str:
+    if not reading.endswith(old):
+        return reading + new
+    return reading[: -len(old)] + new
+
+
+def _minute_parts(digits: str) -> tuple[str, str]:
+    value = int(digits)
+    base = integer_reading(digits)
+    last = value % 10
+    if base.endswith("ひゃく") or base.endswith("びゃく") or base.endswith("ぴゃく"):
+        return base[:-1] + "っ", "ぷん"
+    if last == 1:
+        return _replace_ending(base, "いち", "いっ"), "ぷん"
+    if last == 6:
+        return _replace_ending(base, "ろく", "ろっ"), "ぷん"
+    if last == 8:
+        return _replace_ending(base, "はち", "はっ"), "ぷん"
+    if last == 0 and base.endswith("じゅう"):
+        return base[:-1] + "っ", "ぷん"
+    return base, "ぷん" if last in {3, 4} else "ふん"
+
+
+def _night_parts(digits: str) -> tuple[str, str]:
+    value = int(digits)
+    base = integer_reading(digits)
+    last = value % 10
+    if last == 1:
+        return _replace_ending(base, "いち", "いっ"), "ぱく"
+    if last == 3:
+        return base, "ぱく"
+    if last == 6:
+        return _replace_ending(base, "ろく", "ろっ"), "ぱく"
+    if last == 8:
+        return _replace_ending(base, "はち", "はっ"), "ぱく"
+    if last == 0 and base.endswith("じゅう"):
+        return base[:-1] + "っ", "ぱく"
+    return base, "はく"
+
+
+def _day_parts(digits: str, *, follows_month: bool) -> tuple[str, str]:
+    value = int(digits)
+    special = {
+        1: "ついたち" if follows_month else "いちにち",
+        2: "ふつか",
+        3: "みっか",
+        4: "よっか",
+        5: "いつか",
+        6: "むいか",
+        7: "なのか",
+        8: "ようか",
+        9: "ここのか",
+        10: "とおか",
+        14: "じゅうよっか",
+        20: "はつか",
+        24: "にじゅうよっか",
+    }.get(value)
+    if special is None:
+        return integer_reading(digits), "にち"
+    if special.endswith("か"):
+        return special[:-1], "か"
+    if special.endswith("にち"):
+        return special[:-2], "にち"
+    return special, ""
+
+
+def _counter_parts(
+    digits: str,
+    counter: str,
+    *,
+    follows_month: bool,
+) -> tuple[NumericReadingPart, ...]:
+    value = int(digits)
+    number_reading: str
+    counter_reading: str
+
+    if counter == "人":
+        if value == 1:
+            number_reading, counter_reading = "ひと", "り"
+        elif value == 2:
+            number_reading, counter_reading = "ふた", "り"
+        else:
+            number_reading, counter_reading = integer_reading(digits), "にん"
+    elif counter == "分":
+        number_reading, counter_reading = _minute_parts(digits)
+    elif counter == "泊":
+        number_reading, counter_reading = _night_parts(digits)
+    elif counter == "つ" and 1 <= value <= 10:
+        whole = {
+            1: "ひとつ",
+            2: "ふたつ",
+            3: "みっつ",
+            4: "よっつ",
+            5: "いつつ",
+            6: "むっつ",
+            7: "ななつ",
+            8: "やっつ",
+            9: "ここのつ",
+            10: "とお",
+        }[value]
+        number_reading, counter_reading = (
+            (whole[:-1], whole[-1]) if value != 10 else (whole, "")
+        )
+    elif counter == "丁目":
+        number_reading, counter_reading = integer_reading(digits), "ちょうめ"
+    elif counter == "月":
+        number_reading = {4: "し", 7: "しち", 9: "く"}.get(
+            value,
+            integer_reading(digits),
+        )
+        counter_reading = "がつ"
+    elif counter == "日":
+        number_reading, counter_reading = _day_parts(
+            digits,
+            follows_month=follows_month,
+        )
+    elif counter in {"時", "時半"}:
+        number_reading = {4: "よ", 7: "しち", 9: "く"}.get(
+            value,
+            integer_reading(digits),
+        )
+        counter_reading = "じ" + ("はん" if counter == "時半" else "")
+    else:
+        number_reading, counter_reading = integer_reading(digits), counter
+
+    if not counter_reading:
+        return (
+            NumericReadingPart(
+                surface=digits + counter,
+                reading=number_reading,
+            ),
+        )
+    return (
+        NumericReadingPart(surface=digits, reading=number_reading),
+        NumericReadingPart(surface=counter, reading=counter_reading),
+    )
+
+
+def resolve_numeric_span(
+    surfaces: Sequence[str],
+    index: int,
+) -> NumericReadingSpan | None:
+    digits = surfaces[index]
+    if _ASCII_DIGITS.fullmatch(digits) is None:
+        return None
+
+    following = surfaces[index + 1] if index + 1 < len(surfaces) else None
+    if following in _COUNTERS:
+        follows_month = index >= 2 and surfaces[index - 1] == "月"
+        return NumericReadingSpan(
+            consumed_items=2,
+            parts=_counter_parts(
+                digits,
+                following,
+                follows_month=follows_month,
+            ),
+        )
+
+    is_standard_cardinal = bool(
+        following
+        and _JAPANESE_TEXT.search(following)
+        and not following.startswith(("、", "。"))
+    )
+    reading = (
+        integer_reading(digits)
+        if is_standard_cardinal and not (len(digits) > 1 and digits.startswith("0"))
+        else "".join(_DIGIT_READINGS[int(character)] for character in digits)
+    )
+    return NumericReadingSpan(
+        consumed_items=1,
+        parts=(NumericReadingPart(surface=digits, reading=reading),),
+    )

--- a/backend/app/lyrics/processor.py
+++ b/backend/app/lyrics/processor.py
@@ -11,6 +11,7 @@ from janome.tokenizer import Tokenizer
 from pykakasi import kakasi
 
 from app.lyrics.models import LyricDocument, LyricLine, LyricToken
+from app.lyrics.numeric_reading import resolve_numeric_span
 from app.core.event_logging import exception_details
 
 
@@ -366,8 +367,20 @@ class LocalJapaneseLyricProcessor:
 
     def _plain_tokens(self, text: str) -> list[LyricToken]:
         tokens: list[LyricToken] = []
-        for item in self.tokenizer.tokenize(text):
+        items = list(self.tokenizer.tokenize(text))
+        surfaces = [item.surface for item in items]
+        index = 0
+        while index < len(items):
+            item = items[index]
             surface = item.surface
+            numeric = resolve_numeric_span(surfaces, index)
+            if numeric is not None:
+                tokens.extend(
+                    LyricToken(surface=part.surface, reading=part.reading)
+                    for part in numeric.parts
+                )
+                index += numeric.consumed_items
+                continue
             alignment_pronunciation = None
             major_part = item.part_of_speech.split(",", maxsplit=1)[0]
             if _LATIN_OR_DIGIT.search(surface) or item.reading == "*":
@@ -385,6 +398,7 @@ class LocalJapaneseLyricProcessor:
                     alignment_pronunciation=alignment_pronunciation,
                 )
             )
+            index += 1
         return split_tokens_by_kanji(tokens)
 
     def _annotated_tokens(self, source: str) -> list[LyricToken]:

--- a/backend/app/lyrics/processor.py
+++ b/backend/app/lyrics/processor.py
@@ -370,6 +370,10 @@ class LocalJapaneseLyricProcessor:
             surface = item.surface
             alignment_pronunciation = None
             major_part = item.part_of_speech.split(",", maxsplit=1)[0]
+            if _LATIN_OR_DIGIT.search(surface) or item.reading == "*":
+                reading = self._surface_reading(surface)
+            else:
+                reading = self._hiragana(item.reading)
             if major_part == "助詞" and surface == "は":
                 alignment_pronunciation = "wa"
             elif major_part == "助詞" and surface == "へ":
@@ -377,7 +381,7 @@ class LocalJapaneseLyricProcessor:
             tokens.append(
                 LyricToken(
                     surface=surface,
-                    reading=self._surface_reading(surface),
+                    reading=reading,
                     alignment_pronunciation=alignment_pronunciation,
                 )
             )

--- a/backend/app/lyrics/processor.py
+++ b/backend/app/lyrics/processor.py
@@ -15,24 +15,23 @@ from app.lyrics.numeric_reading import resolve_numeric_span
 from app.core.event_logging import exception_details
 
 
-SYSTEM_PROMPT = """
-你是日语歌词格式化器。只输出 JSON，不要输出 Markdown。
-保持输入行顺序，为每行生成：
-- surface：修正明显表记错误后的歌词
-- reading：整行平假名读音
-- tokens：用于 Ruby 注音的 surface/reading 数组；每个汉字必须单独作为一个 token，
-  后续连续假名可以合并为一个 token，不得把多个汉字放在同一个 token 中
-  例如「物語」拆成「物/もの」「語/がたり」，
-  「知らない」拆成「知/し」「らない/らない」
-- surface 中的英文或数字必须保留原表记；对应的整行 reading 和 token reading
-  必须根据歌词中的实际唱法改写为平假名，不得保留英文字母或数字，
-  例如「LOVE 39」可写为「LOVE/らぶ」「39/さんきゅー」
-tokens 的 surface 拼接必须严格等于该行 surface。
-输出格式：{"lines":[{"surface":"...","reading":"...","tokens":[...]}]}
+DEEPSEEK_REVIEW_PROMPT = """
+你是日语歌词读音审阅器。只输出 JSON，不要输出 Markdown。
+输入已经由本地日语处理器生成，包含不可修改的 surface 和 token 索引。
+只报告必须依赖日语上下文修正的最小连续 token 范围，不要重新生成全文或 token。
+不得修改歌词表面文字，不得修正含英文或数字的范围，也不得声称根据未提供的音频判断实际唱法。
+没有需要修正的内容时输出 {"corrections":[]}。
+输出格式：
+{"corrections":[{"line_index":0,"start_token":0,"end_token":1,
+"surface":"...","current_reading":"...","corrected_reading":"..."}]}
+end_token 使用 exclusive 下标。
 """.strip()
 
 _FA_KARA_ROMAJI = re.compile(r"[A-Za-z']+")
 _LATIN_OR_DIGIT = re.compile(r"[A-Za-z0-9]")
+_HIRAGANA_READING = re.compile(r"[ぁ-ゖゝゞー・ 　]+")
+_HIRAGANA_CHARACTER = re.compile(r"[ぁ-ゖゝゞ]")
+_KANJI_SEGMENT_READING = re.compile(r"[ぁ-ゖゝゞー・]+")
 _SMALL_KANA = frozenset("ゃゅょぁぃぅぇぉゎゕゖっー")
 _READING_CONVERTER = kakasi()
 _FOREIGN_READING_PARTS = re.compile(r"[A-Za-z]+|[0-9]+|[^A-Za-z0-9]+")
@@ -258,77 +257,179 @@ def normalized_lines(text: str) -> list[str]:
     return [line.strip() for line in text.splitlines() if line.strip()]
 
 
-def has_unconverted_latin_or_digits(response: dict[str, Any]) -> bool:
-    for line in response.get("lines", []):
-        if (
-            _LATIN_OR_DIGIT.search(str(line.get("surface", "")))
-            and _LATIN_OR_DIGIT.search(str(line.get("reading", "")))
-        ):
-            return True
-        for token in line.get("tokens", []):
-            if (
-                _LATIN_OR_DIGIT.search(str(token.get("surface", "")))
-                and _LATIN_OR_DIGIT.search(str(token.get("reading", "")))
-            ):
-                return True
-    return False
-
-
 class LyricProcessingError(ValueError):
     """Raised when an AI lyric response cannot be safely consumed."""
 
 
-class DeepSeekLyricProcessor:
+class DeepSeekReadingReviewer:
     def __init__(self, *, client: Any) -> None:
         self.client = client
 
-    def process(self, text: str) -> LyricDocument:
-        if contains_fa_kara_annotations(text):
-            return LocalJapaneseLyricProcessor().process(text)
-        source_lines = normalized_lines(text)
-        source_text = "\n".join(source_lines)
-        request_payload: dict[str, Any] = {"lines": source_lines}
+    def review(self, document: LyricDocument) -> LyricDocument:
+        request_payload = {
+            "lines": [
+                {
+                    "line_index": line_index,
+                    "surface": line.surface,
+                    "tokens": [
+                        {
+                            "token_index": token_index,
+                            "surface": token.surface,
+                            "reading": token.reading,
+                        }
+                        for token_index, token in enumerate(line.tokens)
+                    ],
+                }
+                for line_index, line in enumerate(document.lines)
+            ]
+        }
         response = self.client.complete_json(
-            system_prompt=SYSTEM_PROMPT,
+            system_prompt=DEEPSEEK_REVIEW_PROMPT,
             user_prompt=json.dumps(request_payload, ensure_ascii=False),
         )
-        if has_unconverted_latin_or_digits(response):
-            request_payload["纠正"] = (
-                "上一次结果仍在 reading 中保留了英文或数字。请保持 surface "
-                "不变，并按实际唱法把对应 reading 全部改为平假名。"
-            )
-            response = self.client.complete_json(
-                system_prompt=SYSTEM_PROMPT,
-                user_prompt=json.dumps(request_payload, ensure_ascii=False),
-            )
-            if has_unconverted_latin_or_digits(response):
+        if not isinstance(response, dict) or not isinstance(
+            response.get("corrections"), list
+        ):
+            raise LyricProcessingError("review response must contain corrections list")
+
+        validated: list[dict[str, Any]] = []
+        for raw_correction in response["corrections"]:
+            if not isinstance(raw_correction, dict):
+                raise LyricProcessingError("correction must be an object")
+            try:
+                line_index = raw_correction["line_index"]
+                start = raw_correction["start_token"]
+                end = raw_correction["end_token"]
+                surface = str(raw_correction["surface"])
+                current_reading = str(raw_correction["current_reading"])
+                corrected_reading = str(raw_correction["corrected_reading"])
+            except KeyError as exc:
+                raise LyricProcessingError("correction fields are invalid") from exc
+            if any(type(value) is not int for value in (line_index, start, end)):
                 raise LyricProcessingError(
-                    "automatic English or numeric kana reading was not generated"
+                    "correction indices must be JSON integers"
                 )
-        lines: list[LyricLine] = []
-        for source, result in zip(source_lines, response["lines"], strict=True):
-            tokens = [
+
+            if not 0 <= line_index < len(document.lines):
+                raise LyricProcessingError("correction line is out of bounds")
+            line = document.lines[line_index]
+            if not 0 <= start < end <= len(line.tokens):
+                raise LyricProcessingError("correction token range is invalid")
+            selected = line.tokens[start:end]
+            rebuilt_surface = "".join(token.surface for token in selected)
+            rebuilt_reading = "".join(token.reading for token in selected)
+            if rebuilt_surface != surface:
+                raise LyricProcessingError("correction surface does not match tokens")
+            if rebuilt_reading != current_reading:
+                raise LyricProcessingError(
+                    "correction current reading does not match tokens"
+                )
+            if corrected_reading == current_reading:
+                raise LyricProcessingError("correction is a no-op")
+            if _LATIN_OR_DIGIT.search(rebuilt_surface):
+                raise LyricProcessingError(
+                    "correction range contains Latin or digits"
+                )
+            if any(
+                token.alignment_pronunciation is not None for token in selected
+            ):
+                raise LyricProcessingError(
+                    "correction range contains alignment pronunciation"
+                )
+            if (
+                _HIRAGANA_CHARACTER.search(corrected_reading) is None
+                or _HIRAGANA_READING.fullmatch(corrected_reading) is None
+            ):
+                raise LyricProcessingError(
+                    "corrected reading must be non-empty hiragana"
+                )
+
+            pattern_parts = ["^"]
+            for is_kanji, segment in _surface_segments(rebuilt_surface):
+                pattern_parts.append(
+                    "(.+?)"
+                    if is_kanji
+                    else re.escape(_reading_for_literal_surface(segment))
+                )
+            pattern_parts.append("$")
+            anchor_match = re.fullmatch(
+                "".join(pattern_parts),
+                corrected_reading,
+            )
+            if anchor_match is None:
+                raise LyricProcessingError(
+                    "correction does not preserve literal kana"
+                )
+            if any(
+                _KANJI_SEGMENT_READING.fullmatch(reading) is None
+                for reading in anchor_match.groups()
+            ):
+                raise LyricProcessingError(
+                    "correction kanji reading contains invalid whitespace"
+                )
+            replacement = split_token_by_kanji(
                 LyricToken(
-                    surface=token["surface"],
-                    reading=token["reading"],
+                    surface=rebuilt_surface,
+                    reading=corrected_reading,
                 )
-                for token in result["tokens"]
-            ]
-            if "".join(token.surface for token in tokens) != result["surface"]:
-                raise LyricProcessingError("tokens do not reconstruct surface")
-            tokens = split_tokens_by_kanji(tokens)
-            lines.append(
-                LyricLine(
-                    source=source,
-                    surface=result["surface"],
-                    reading=result["reading"],
+            )
+            if (
+                any(not token.reading.strip() for token in replacement)
+                or "".join(token.surface for token in replacement)
+                != rebuilt_surface
+                or "".join(token.reading for token in replacement)
+                != corrected_reading
+            ):
+                raise LyricProcessingError(
+                    "correction would create an empty token reading"
+                )
+            validated.append(
+                {
+                    "line_index": line_index,
+                    "start_token": start,
+                    "end_token": end,
+                    "surface": surface,
+                    "corrected_reading": corrected_reading,
+                    "replacement": replacement,
+                }
+            )
+
+        corrections_by_line: dict[int, list[dict[str, Any]]] = {}
+        for correction in validated:
+            corrections_by_line.setdefault(correction["line_index"], []).append(
+                correction
+            )
+        for corrections in corrections_by_line.values():
+            ordered = sorted(corrections, key=lambda item: item["start_token"])
+            if any(
+                left["end_token"] > right["start_token"]
+                for left, right in zip(ordered, ordered[1:])
+            ):
+                raise LyricProcessingError("correction ranges overlap")
+
+        reviewed_lines: list[LyricLine] = []
+        for line_index, line in enumerate(document.lines):
+            tokens = list(line.tokens)
+            corrections = corrections_by_line.get(line_index, [])
+            for correction in sorted(
+                corrections,
+                key=lambda item: item["start_token"],
+                reverse=True,
+            ):
+                start = correction["start_token"]
+                end = correction["end_token"]
+                tokens[start:end] = correction["replacement"]
+            reviewed_lines.append(
+                replace(
+                    line,
+                    reading="".join(token.reading for token in tokens),
                     tokens=tokens,
                 )
             )
-        return LyricDocument(
-            provider="deepseek",
-            source_text=source_text,
-            lines=lines,
+        return replace(
+            document,
+            provider="local+deepseek",
+            lines=reviewed_lines,
         )
 
 
@@ -522,21 +623,25 @@ def normalize_unconverted_foreign_readings(
     return replace(document, lines=normalized_lines)
 
 
-class ResilientLyricProcessor:
+class ReviewedLyricProcessor:
     def __init__(
         self,
         *,
-        primary: Any,
-        fallback: Any,
+        base: Any,
+        reviewer: Any,
         event_logger: Any | None = None,
     ) -> None:
-        self.primary = primary
-        self.fallback = fallback
+        self.base = base
+        self.reviewer = reviewer
         self.event_logger = event_logger
 
     def process(self, text: str) -> LyricDocument:
+        document = self.base.process(text)
+        if contains_fa_kara_annotations(text):
+            return document
+
         source_lines = normalized_lines(text)
-        client = getattr(self.primary, "client", None)
+        client = getattr(self.reviewer, "client", None)
         call_details = {
             "attempt": 1,
             "character_count": sum(len(line) for line in source_lines),
@@ -550,25 +655,25 @@ class ResilientLyricProcessor:
                 event="external.started",
                 level="INFO",
                 category="external",
-                message="开始调用 DeepSeek 处理歌词注音",
+                message="DeepSeek 开始本地读音审阅",
                 component="deepseek",
                 details=call_details,
             )
         try:
-            document = self.primary.process(text)
+            reviewed = self.reviewer.review(document)
         except Exception as exc:
             if self.event_logger is not None:
                 self.event_logger.emit(
                     event="external.failed",
                     level="WARNING",
                     category="external",
-                    message="DeepSeek 歌词处理失败，将使用本地处理器",
+                    message="DeepSeek 审阅失败，保留本地结果",
                     component="deepseek",
                     duration_ms=(time.perf_counter() - started) * 1000,
                     details={
                         "attempt": 1,
                         "retry_count": 0,
-                        "fallback_component": type(self.fallback).__name__,
+                        "fallback_component": type(self.base).__name__,
                         **exception_details(exc),
                     },
                 )
@@ -576,19 +681,18 @@ class ResilientLyricProcessor:
                     event="stage.fallback",
                     level="WARNING",
                     category="pipeline",
-                    message="歌词处理切换到本地注音处理器",
+                    message="DeepSeek 审阅失败，保留本地结果",
                     component="deepseek",
                     details={
-                        "reason": "deepseek_unavailable",
-                        "fallback_component": type(self.fallback).__name__,
+                        "reason": "deepseek_review_failed",
+                        "fallback_component": type(self.base).__name__,
                     },
                 )
-            document = self.fallback.process(text)
             return replace(
                 document,
                 warnings=[
                     *document.warnings,
-                    f"deepseek_fallback:{type(exc).__name__}",
+                    f"deepseek_review_failed:{type(exc).__name__}",
                 ],
             )
         if self.event_logger is not None:
@@ -596,14 +700,14 @@ class ResilientLyricProcessor:
                 event="external.completed",
                 level="INFO",
                 category="external",
-                message="DeepSeek 歌词注音处理完成",
+                message="DeepSeek 完成本地读音审阅",
                 component="deepseek",
                 duration_ms=(time.perf_counter() - started) * 1000,
                 details={
                     "attempt": 1,
-                    "provider": document.provider,
-                    "result_line_count": len(document.lines),
-                    "warning_count": len(document.warnings),
+                    "provider": reviewed.provider,
+                    "result_line_count": len(reviewed.lines),
+                    "warning_count": len(reviewed.warnings),
                 },
             )
-        return document
+        return reviewed

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -32,9 +32,9 @@ from app.core.worker_config import (
 )
 from app.schemas.jobs import HealthResponse
 from app.lyrics.processor import (
-    DeepSeekLyricProcessor,
+    DeepSeekReadingReviewer,
     LocalJapaneseLyricProcessor,
-    ResilientLyricProcessor,
+    ReviewedLyricProcessor,
 )
 from app.tasks.pipeline import TranscriptionPipeline
 from app.tasks.runner import LocalTaskRunner
@@ -97,8 +97,9 @@ def build_pipeline(
 ) -> TranscriptionPipeline:
     local_lyric_processor = LocalJapaneseLyricProcessor()
     if settings.deepseek_api_key is not None:
-        lyric_processor = ResilientLyricProcessor(
-            primary=DeepSeekLyricProcessor(
+        lyric_processor = ReviewedLyricProcessor(
+            base=local_lyric_processor,
+            reviewer=DeepSeekReadingReviewer(
                 client=DeepSeekClient(
                     api_key=settings.deepseek_api_key.get_secret_value(),
                     base_url=settings.deepseek_base_url,
@@ -106,7 +107,6 @@ def build_pipeline(
                     timeout_seconds=settings.deepseek_timeout_seconds,
                 )
             ),
-            fallback=local_lyric_processor,
             event_logger=database.event_logger,
         )
     else:

--- a/backend/app/tasks/pipeline.py
+++ b/backend/app/tasks/pipeline.py
@@ -483,6 +483,7 @@ class TranscriptionPipeline:
                         warning
                         for warning in processed_lyrics.warnings
                         if "fallback" in warning.lower()
+                        or warning.startswith("deepseek_review_failed:")
                     ]
                     if fallback_warnings:
                         lyric_trace.fallback(
@@ -992,22 +993,22 @@ class TranscriptionPipeline:
         )
 
     def _lyric_component(self) -> str:
-        primary = getattr(self.lyric_processor, "primary", None)
-        return "deepseek" if primary is not None else type(
+        reviewer = getattr(self.lyric_processor, "reviewer", None)
+        return "deepseek" if reviewer is not None else type(
             self.lyric_processor
         ).__name__
 
     def _lyric_processor_details(self) -> dict[str, Any]:
-        primary = getattr(self.lyric_processor, "primary", None)
-        fallback = getattr(self.lyric_processor, "fallback", None)
-        client = getattr(primary, "client", None)
+        reviewer = getattr(self.lyric_processor, "reviewer", None)
+        base = getattr(self.lyric_processor, "base", None)
+        client = getattr(reviewer, "client", None)
         return {
             "processor": type(self.lyric_processor).__name__,
-            "primary_processor": type(primary).__name__
-            if primary is not None
+            "reviewer": type(reviewer).__name__
+            if reviewer is not None
             else None,
-            "fallback_processor": type(fallback).__name__
-            if fallback is not None
+            "base_processor": type(base).__name__
+            if base is not None
             else None,
             "model": getattr(client, "model", None),
             "timeout_seconds": getattr(client, "timeout_seconds", None),

--- a/backend/tests/test_app_lifespan.py
+++ b/backend/tests/test_app_lifespan.py
@@ -13,7 +13,7 @@ from app.alignment.mms import MMSForcedAligner, SubprocessMMSRuntime
 from app.main import create_app
 from app.lyrics.processor import (
     LocalJapaneseLyricProcessor,
-    ResilientLyricProcessor,
+    ReviewedLyricProcessor,
 )
 from app.tasks.runner import LocalTaskRunner
 from app.vocal.mdx import MDXNetVocalRemover
@@ -182,7 +182,7 @@ def test_app_hot_reloads_processing_worker_count(tmp_path: Path) -> None:
         assert snapshot["alive_workers"] == 4
 
 
-def test_app_prefers_deepseek_when_api_key_is_configured(tmp_path: Path) -> None:
+def test_app_adds_deepseek_review_when_api_key_is_configured(tmp_path: Path) -> None:
     settings = Settings(
         data_dir=tmp_path / "data",
         storage_dir=tmp_path / "jobs",
@@ -194,10 +194,10 @@ def test_app_prefers_deepseek_when_api_key_is_configured(tmp_path: Path) -> None
 
     with TestClient(app):
         processor = app.state.runner.pipeline.lyric_processor
-        assert isinstance(processor, ResilientLyricProcessor)
-        assert processor.primary.client.model == "deepseek-v4-flash"
-        assert processor.primary.client.api_key == "secret"
-        assert isinstance(processor.fallback, LocalJapaneseLyricProcessor)
+        assert isinstance(processor, ReviewedLyricProcessor)
+        assert processor.reviewer.client.model == "deepseek-v4-flash"
+        assert processor.reviewer.client.api_key == "secret"
+        assert isinstance(processor.base, LocalJapaneseLyricProcessor)
 
 
 def test_app_uses_configured_mdx_net_vocal_remover(

--- a/backend/tests/test_lyric_processor.py
+++ b/backend/tests/test_lyric_processor.py
@@ -299,6 +299,59 @@ def test_local_processor_generates_editable_kana_for_latin_words_and_digits() ->
     assert re.search(r"[A-Za-z0-9]", line.reading) is None
 
 
+@pytest.mark.parametrize(
+    ("surface", "reading"),
+    [
+        ("80億分の1", "はちじゅうおくぶんのいち"),
+        ("1000メーター", "せんめーたー"),
+        ("100分", "ひゃっぷん"),
+        ("3泊4日", "さんぱくよっか"),
+        ("1人", "ひとり"),
+        ("8月15日", "はちがつじゅうごにち"),
+        ("午後12時半", "ごごじゅうにじはん"),
+    ],
+)
+def test_local_processor_resolves_standard_numeric_phrases(
+    surface: str,
+    reading: str,
+) -> None:
+    processor_module = importlib.import_module("app.lyrics.processor")
+    processor = processor_module.LocalJapaneseLyricProcessor()
+
+    document = processor.process(surface)
+
+    line = document.lines[0]
+    assert line.surface == surface
+    assert line.reading == reading
+    assert "".join(token.surface for token in line.tokens) == surface
+
+
+def test_local_processor_keeps_calendar_date_token_readings_nonempty() -> None:
+    processor_module = importlib.import_module("app.lyrics.processor")
+    processor = processor_module.LocalJapaneseLyricProcessor()
+
+    document = processor.process("1月1日")
+
+    line = document.lines[0]
+    assert line.reading == "いちがつついたち"
+    assert all(token.reading for token in line.tokens)
+
+
+@pytest.mark.parametrize("surface", ["12345ire", "50:50", "321", "1LDK"])
+def test_local_processor_keeps_ambiguous_numeric_surface_editable(
+    surface: str,
+) -> None:
+    processor_module = importlib.import_module("app.lyrics.processor")
+    processor = processor_module.LocalJapaneseLyricProcessor()
+
+    document = processor.process(surface)
+
+    line = document.lines[0]
+    assert line.surface == surface
+    assert "".join(token.surface for token in line.tokens) == surface
+    assert re.search(r"[A-Za-z0-9]", line.reading) is None
+
+
 def test_local_processor_parses_fa_kara_explicit_annotations() -> None:
     processor_module = importlib.import_module("app.lyrics.processor")
     processor = processor_module.LocalJapaneseLyricProcessor()

--- a/backend/tests/test_lyric_processor.py
+++ b/backend/tests/test_lyric_processor.py
@@ -216,6 +216,38 @@ def test_local_processor_generates_hiragana_and_tokens() -> None:
     assert document.warnings == ["local_reading_may_be_inaccurate"]
 
 
+def test_local_processor_prefers_janome_compound_reading() -> None:
+    processor_module = importlib.import_module("app.lyrics.processor")
+    processor = processor_module.LocalJapaneseLyricProcessor()
+
+    document = processor.process("泣き声")
+
+    line = document.lines[0]
+    assert line.reading == "なきごえ"
+    assert [(token.surface, token.reading) for token in line.tokens] == [
+        ("泣", "な"),
+        ("き", "き"),
+        ("声", "ごえ"),
+    ]
+
+
+def test_local_processor_prefers_janome_contextual_reading() -> None:
+    processor_module = importlib.import_module("app.lyrics.processor")
+    processor = processor_module.LocalJapaneseLyricProcessor()
+
+    document = processor.process("君は")
+
+    line = document.lines[0]
+    assert line.reading == "きみは"
+    assert [
+        (token.surface, token.reading, token.alignment_pronunciation)
+        for token in line.tokens
+    ] == [
+        ("君", "きみ", None),
+        ("は", "は", "wa"),
+    ]
+
+
 def test_local_processor_keeps_ambiguous_compound_reading_complete() -> None:
     processor_module = importlib.import_module("app.lyrics.processor")
     processor = processor_module.LocalJapaneseLyricProcessor()

--- a/backend/tests/test_lyric_processor.py
+++ b/backend/tests/test_lyric_processor.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import importlib
+import json
 import re
+from dataclasses import replace
 
 import pytest
 
@@ -16,183 +18,6 @@ class FakeJsonClient:
     def complete_json(self, *, system_prompt: str, user_prompt: str) -> dict:
         self.calls.append((system_prompt, user_prompt))
         return self.response
-
-
-def test_deepseek_processor_returns_ruby_ready_lyrics() -> None:
-    try:
-        processor_module = importlib.import_module("app.lyrics.processor")
-    except ModuleNotFoundError:
-        pytest.fail("DeepSeek lyric processor is not implemented")
-
-    client = FakeJsonClient(
-        {
-            "lines": [
-                {
-                    "surface": "君の知らない物語",
-                    "reading": "きみのしらないものがたり",
-                    "tokens": [
-                        {"surface": "君", "reading": "きみ"},
-                        {"surface": "の", "reading": "の"},
-                        {"surface": "知らない", "reading": "しらない"},
-                        {"surface": "物語", "reading": "ものがたり"},
-                    ],
-                }
-            ]
-        }
-    )
-    processor = processor_module.DeepSeekLyricProcessor(client=client)
-
-    document = processor.process("  君の知らない物語  \n\n")
-
-    assert document.provider == "deepseek"
-    assert document.source_text == "君の知らない物語"
-    assert len(document.lines) == 1
-    line = document.lines[0]
-    assert line.source == "君の知らない物語"
-    assert line.surface == "君の知らない物語"
-    assert line.reading == "きみのしらないものがたり"
-    assert "".join(token.surface for token in line.tokens) == line.surface
-    assert [(token.surface, token.reading) for token in line.tokens] == [
-        ("君", "きみ"),
-        ("の", "の"),
-        ("知", "し"),
-        ("らない", "らない"),
-        ("物", "もの"),
-        ("語", "がたり"),
-    ]
-    assert client.calls
-    assert "JSON" in client.calls[0][0]
-    assert "每个汉字" in client.calls[0][0]
-
-
-def test_deepseek_processor_requests_kana_readings_for_latin_and_digits() -> None:
-    processor_module = importlib.import_module("app.lyrics.processor")
-    client = FakeJsonClient(
-        {
-            "lines": [
-                {
-                    "surface": "LOVE 39",
-                    "reading": "らぶ さんきゅー",
-                    "tokens": [
-                        {"surface": "LOVE", "reading": "らぶ"},
-                        {"surface": " ", "reading": " "},
-                        {"surface": "39", "reading": "さんきゅー"},
-                    ],
-                }
-            ]
-        }
-    )
-
-    document = processor_module.DeepSeekLyricProcessor(client=client).process(
-        "LOVE 39"
-    )
-
-    prompt = client.calls[0][0]
-    assert "英文或数字" in prompt
-    assert "实际唱法" in prompt
-    assert "平假名" in prompt
-    assert document.lines[0].reading == "らぶ さんきゅー"
-
-
-def test_deepseek_processor_retries_unconverted_latin_reading_once() -> None:
-    processor_module = importlib.import_module("app.lyrics.processor")
-
-    class SequenceJsonClient:
-        def __init__(self) -> None:
-            self.calls: list[tuple[str, str]] = []
-            self.responses = [
-                {
-                    "lines": [
-                        {
-                            "surface": "LOVE",
-                            "reading": "LOVE",
-                            "tokens": [
-                                {"surface": "LOVE", "reading": "LOVE"}
-                            ],
-                        }
-                    ]
-                },
-                {
-                    "lines": [
-                        {
-                            "surface": "LOVE",
-                            "reading": "らぶ",
-                            "tokens": [
-                                {"surface": "LOVE", "reading": "らぶ"}
-                            ],
-                        }
-                    ]
-                },
-            ]
-
-        def complete_json(self, *, system_prompt: str, user_prompt: str) -> dict:
-            self.calls.append((system_prompt, user_prompt))
-            return self.responses[len(self.calls) - 1]
-
-    client = SequenceJsonClient()
-    document = processor_module.DeepSeekLyricProcessor(client=client).process(
-        "LOVE"
-    )
-
-    assert len(client.calls) == 2
-    assert "纠正" in client.calls[1][1]
-    assert document.lines[0].reading == "らぶ"
-    assert document.lines[0].tokens[0].reading == "らぶ"
-
-
-def test_deepseek_processor_rejects_unconverted_reading_after_retry() -> None:
-    processor_module = importlib.import_module("app.lyrics.processor")
-
-    class InvalidJsonClient:
-        def __init__(self) -> None:
-            self.call_count = 0
-
-        def complete_json(self, *, system_prompt: str, user_prompt: str) -> dict:
-            self.call_count += 1
-            return {
-                "lines": [
-                    {
-                        "surface": "LOVE",
-                        "reading": "LOVE",
-                        "tokens": [
-                            {"surface": "LOVE", "reading": "LOVE"}
-                        ],
-                    }
-                ]
-            }
-
-    client = InvalidJsonClient()
-    with pytest.raises(
-        processor_module.LyricProcessingError,
-        match="kana reading",
-    ):
-        processor_module.DeepSeekLyricProcessor(client=client).process("LOVE")
-
-    assert client.call_count == 2
-
-
-def test_deepseek_processor_rejects_tokens_that_change_surface() -> None:
-    processor_module = importlib.import_module("app.lyrics.processor")
-    client = FakeJsonClient(
-        {
-            "lines": [
-                {
-                    "surface": "君の知らない物語",
-                    "reading": "きみのしらないものがたり",
-                    "tokens": [
-                        {"surface": "君の物語", "reading": "きみのものがたり"}
-                    ],
-                }
-            ]
-        }
-    )
-    processor = processor_module.DeepSeekLyricProcessor(client=client)
-
-    with pytest.raises(
-        processor_module.LyricProcessingError,
-        match="tokens do not reconstruct surface",
-    ):
-        processor.process("君の知らない物語")
 
 
 def test_local_processor_generates_hiragana_and_tokens() -> None:
@@ -397,16 +222,365 @@ def test_local_processor_rejects_malformed_fa_kara_annotations() -> None:
         processor.process("{知|しる")
 
 
-def test_resilient_processor_falls_back_when_deepseek_fails() -> None:
+def test_deepseek_reviewer_applies_contextual_patch_to_local_tokens() -> None:
     processor_module = importlib.import_module("app.lyrics.processor")
-    if not hasattr(processor_module, "ResilientLyricProcessor"):
-        pytest.fail("Resilient lyric processor is not implemented")
+    local = processor_module.LocalJapaneseLyricProcessor().process(
+        "無き声\n君は"
+    )
+    client = FakeJsonClient(
+        {
+            "corrections": [
+                {
+                    "line_index": 0,
+                    "start_token": 0,
+                    "end_token": 3,
+                    "surface": "無き声",
+                    "current_reading": "なきこえ",
+                    "corrected_reading": "なきごえ",
+                }
+            ]
+        }
+    )
+    reviewer = processor_module.DeepSeekReadingReviewer(client=client)
 
-    class FailingPrimary:
-        def process(self, text: str) -> LyricDocument:
-            raise RuntimeError("DeepSeek unavailable")
+    reviewed = reviewer.review(local)
 
-    class RecordingFallback:
+    assert reviewed.provider == "local+deepseek"
+    assert reviewed.lines[0].surface == "無き声"
+    assert reviewed.lines[0].reading == "なきごえ"
+    assert reviewed.lines[1].reading == "きみは"
+    assert reviewed.lines[1].tokens[-1].alignment_pronunciation == "wa"
+    payload = json.loads(client.calls[0][1])
+    prompt = client.calls[0][0]
+    assert "不得修改歌词表面文字" in prompt
+    assert "不要重新生成全文或 token" in prompt
+    assert "不得修正含英文或数字的范围" in prompt
+    assert "未提供的音频" in prompt
+    assert payload["lines"][0] == {
+        "line_index": 0,
+        "surface": "無き声",
+        "tokens": [
+            {"token_index": 0, "surface": "無", "reading": "な"},
+            {"token_index": 1, "surface": "き", "reading": "き"},
+            {"token_index": 2, "surface": "声", "reading": "こえ"},
+        ],
+    }
+
+
+def test_deepseek_reviewer_marks_success_when_no_patch_is_needed() -> None:
+    processor_module = importlib.import_module("app.lyrics.processor")
+    local = processor_module.LocalJapaneseLyricProcessor().process("泣き声")
+    reviewer = processor_module.DeepSeekReadingReviewer(
+        client=FakeJsonClient({"corrections": []})
+    )
+
+    reviewed = reviewer.review(local)
+
+    assert reviewed.provider == "local+deepseek"
+    assert reviewed.lines == local.lines
+    assert reviewed.warnings == local.warnings
+
+
+def test_deepseek_reviewer_allows_only_surface_anchored_spaces() -> None:
+    processor_module = importlib.import_module("app.lyrics.processor")
+    local = processor_module.LocalJapaneseLyricProcessor().process("泣き 声")
+    reviewer = processor_module.DeepSeekReadingReviewer(
+        client=FakeJsonClient(
+            {
+                "corrections": [
+                    {
+                        "line_index": 0,
+                        "start_token": 0,
+                        "end_token": 4,
+                        "surface": "泣き 声",
+                        "current_reading": "なき こえ",
+                        "corrected_reading": "なき ごえ",
+                    }
+                ]
+            }
+        )
+    )
+
+    reviewed = reviewer.review(local)
+
+    assert reviewed.lines[0].reading == "なき ごえ"
+    assert [(token.surface, token.reading) for token in reviewed.lines[0].tokens] == [
+        ("泣", "な"),
+        ("き ", "き "),
+        ("声", "ごえ"),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("text", "corrections", "message"),
+    [
+        (
+            "無き声",
+            [
+                {
+                    "line_index": 3,
+                    "start_token": 0,
+                    "end_token": 1,
+                    "surface": "無",
+                    "current_reading": "な",
+                    "corrected_reading": "む",
+                }
+            ],
+            "line",
+        ),
+        (
+            "無き声",
+            [
+                {
+                    "line_index": 0,
+                    "start_token": 1,
+                    "end_token": 1,
+                    "surface": "",
+                    "current_reading": "",
+                    "corrected_reading": "な",
+                }
+            ],
+            "range",
+        ),
+        (
+            "無き声",
+            [
+                {
+                    "line_index": 0,
+                    "start_token": 0,
+                    "end_token": 2,
+                    "surface": "無き",
+                    "current_reading": "なき",
+                    "corrected_reading": "むき",
+                },
+                {
+                    "line_index": 0,
+                    "start_token": 1,
+                    "end_token": 3,
+                    "surface": "き声",
+                    "current_reading": "きこえ",
+                    "corrected_reading": "きごえ",
+                },
+            ],
+            "overlap",
+        ),
+        (
+            "無き声",
+            [
+                {
+                    "line_index": 0,
+                    "start_token": 0,
+                    "end_token": 3,
+                    "surface": "泣き声",
+                    "current_reading": "なきこえ",
+                    "corrected_reading": "なきごえ",
+                }
+            ],
+            "surface",
+        ),
+        (
+            "無き声",
+            [
+                {
+                    "line_index": 0,
+                    "start_token": 0,
+                    "end_token": 3,
+                    "surface": "無き声",
+                    "current_reading": "むきこえ",
+                    "corrected_reading": "なきごえ",
+                }
+            ],
+            "current reading",
+        ),
+        (
+            "1人",
+            [
+                {
+                    "line_index": 0,
+                    "start_token": 0,
+                    "end_token": 1,
+                    "surface": "1",
+                    "current_reading": "ひと",
+                    "corrected_reading": "わん",
+                }
+            ],
+            "Latin or digits",
+        ),
+        (
+            "君は",
+            [
+                {
+                    "line_index": 0,
+                    "start_token": 1,
+                    "end_token": 2,
+                    "surface": "は",
+                    "current_reading": "は",
+                    "corrected_reading": "わ",
+                }
+            ],
+            "alignment pronunciation",
+        ),
+        (
+            "無き声",
+            [
+                {
+                    "line_index": 0,
+                    "start_token": 0,
+                    "end_token": 3,
+                    "surface": "無き声",
+                    "current_reading": "なきこえ",
+                    "corrected_reading": "naki1",
+                }
+            ],
+            "hiragana",
+        ),
+        (
+            "無き声",
+            [
+                {
+                    "line_index": 0,
+                    "start_token": 0,
+                    "end_token": 3,
+                    "surface": "無き声",
+                    "current_reading": "なきこえ",
+                    "corrected_reading": "なごえ",
+                }
+            ],
+            "literal kana",
+        ),
+        (
+            "無き声",
+            [
+                {
+                    "line_index": 0,
+                    "start_token": 0,
+                    "end_token": 3,
+                    "surface": "無き声",
+                    "current_reading": "なきこえ",
+                    "corrected_reading": "なきこえ",
+                }
+            ],
+            "no-op",
+        ),
+        (
+            "物語",
+            [
+                {
+                    "line_index": 0,
+                    "start_token": 0,
+                    "end_token": 2,
+                    "surface": "物語",
+                    "current_reading": "ものがたり",
+                    "corrected_reading": "あ",
+                }
+            ],
+            "empty token reading",
+        ),
+        (
+            "声",
+            [
+                {
+                    "line_index": 0,
+                    "start_token": 0,
+                    "end_token": 1,
+                    "surface": "声",
+                    "current_reading": "こえ",
+                    "corrected_reading": "こえ ",
+                }
+            ],
+            "kanji reading",
+        ),
+        (
+            "声",
+            [
+                {
+                    "line_index": 0,
+                    "start_token": 0,
+                    "end_token": 1,
+                    "surface": "声",
+                    "current_reading": "こえ",
+                    "corrected_reading": "こ え",
+                }
+            ],
+            "kanji reading",
+        ),
+        (
+            "物語",
+            [
+                {
+                    "line_index": 0,
+                    "start_token": 0,
+                    "end_token": 2,
+                    "surface": "物語",
+                    "current_reading": "ものがたり",
+                    "corrected_reading": "あ ",
+                }
+            ],
+            "kanji reading",
+        ),
+        (
+            "無き声",
+            [
+                {
+                    "line_index": 0.5,
+                    "start_token": 0,
+                    "end_token": 3,
+                    "surface": "無き声",
+                    "current_reading": "なきこえ",
+                    "corrected_reading": "なきごえ",
+                }
+            ],
+            "integer",
+        ),
+        (
+            "無き声",
+            [
+                {
+                    "line_index": 0,
+                    "start_token": "0",
+                    "end_token": 3,
+                    "surface": "無き声",
+                    "current_reading": "なきこえ",
+                    "corrected_reading": "なきごえ",
+                }
+            ],
+            "integer",
+        ),
+        (
+            "無き声",
+            [
+                {
+                    "line_index": 0,
+                    "start_token": False,
+                    "end_token": 3,
+                    "surface": "無き声",
+                    "current_reading": "なきこえ",
+                    "corrected_reading": "なきごえ",
+                }
+            ],
+            "integer",
+        ),
+    ],
+)
+def test_deepseek_reviewer_rejects_unsafe_corrections_atomically(
+    text: str,
+    corrections: list[dict],
+    message: str,
+) -> None:
+    processor_module = importlib.import_module("app.lyrics.processor")
+    local = processor_module.LocalJapaneseLyricProcessor().process(text)
+    reviewer = processor_module.DeepSeekReadingReviewer(
+        client=FakeJsonClient({"corrections": corrections})
+    )
+
+    with pytest.raises(processor_module.LyricProcessingError, match=message):
+        reviewer.review(local)
+
+
+def test_reviewed_processor_keeps_single_local_result_when_review_fails() -> None:
+    processor_module = importlib.import_module("app.lyrics.processor")
+
+    class RecordingBase:
         def __init__(self) -> None:
             self.texts: list[str] = []
 
@@ -418,23 +592,33 @@ def test_resilient_processor_falls_back_when_deepseek_fails() -> None:
                 warnings=["local_reading_may_be_inaccurate"],
             )
 
-    fallback = RecordingFallback()
-    processor = processor_module.ResilientLyricProcessor(
-        primary=FailingPrimary(),
-        fallback=fallback,
+    class FailingReviewer:
+        def __init__(self) -> None:
+            self.documents: list[LyricDocument] = []
+
+        def review(self, document: LyricDocument) -> LyricDocument:
+            self.documents.append(document)
+            raise RuntimeError("DeepSeek unavailable")
+
+    base = RecordingBase()
+    reviewer = FailingReviewer()
+    processor = processor_module.ReviewedLyricProcessor(
+        base=base,
+        reviewer=reviewer,
     )
 
     document = processor.process("物語")
 
-    assert fallback.texts == ["物語"]
+    assert base.texts == ["物語"]
+    assert reviewer.documents[0].source_text == "物語"
     assert document.provider == "local"
     assert document.warnings == [
         "local_reading_may_be_inaccurate",
-        "deepseek_fallback:RuntimeError",
+        "deepseek_review_failed:RuntimeError",
     ]
 
 
-def test_resilient_processor_records_deepseek_call_lifecycle_without_lyrics() -> None:
+def test_reviewed_processor_records_review_lifecycle_without_lyrics() -> None:
     processor_module = importlib.import_module("app.lyrics.processor")
 
     class RecordingEvents:
@@ -445,20 +629,20 @@ def test_resilient_processor_records_deepseek_call_lifecycle_without_lyrics() ->
             self.items.append(event)
             return True
 
-    class Primary:
+    class Reviewer:
         class Client:
             model = "deepseek-test"
             timeout_seconds = 12
 
         client = Client()
 
-        def process(self, text: str) -> LyricDocument:
-            return LyricDocument(provider="deepseek", source_text=text, lines=[])
+        def review(self, document: LyricDocument) -> LyricDocument:
+            return replace(document, provider="local+deepseek")
 
     events = RecordingEvents()
-    processor = processor_module.ResilientLyricProcessor(
-        primary=Primary(),
-        fallback=object(),
+    processor = processor_module.ReviewedLyricProcessor(
+        base=processor_module.LocalJapaneseLyricProcessor(),
+        reviewer=Reviewer(),
         event_logger=events,
     )
 
@@ -479,7 +663,7 @@ def test_resilient_processor_records_deepseek_call_lifecycle_without_lyrics() ->
     assert "秘密の歌詞" not in str(events.items)
 
 
-def test_resilient_processor_records_deepseek_failure_and_fallback() -> None:
+def test_reviewed_processor_records_review_failure_and_keeps_local_result() -> None:
     processor_module = importlib.import_module("app.lyrics.processor")
 
     class RecordingEvents:
@@ -490,18 +674,14 @@ def test_resilient_processor_records_deepseek_failure_and_fallback() -> None:
             self.items.append(event)
             return True
 
-    class FailingPrimary:
-        def process(self, text: str) -> LyricDocument:
+    class FailingReviewer:
+        def review(self, document: LyricDocument) -> LyricDocument:
             raise RuntimeError("temporary upstream failure")
 
-    class Fallback:
-        def process(self, text: str) -> LyricDocument:
-            return LyricDocument(provider="local", source_text=text, lines=[])
-
     events = RecordingEvents()
-    processor = processor_module.ResilientLyricProcessor(
-        primary=FailingPrimary(),
-        fallback=Fallback(),
+    processor = processor_module.ReviewedLyricProcessor(
+        base=processor_module.LocalJapaneseLyricProcessor(),
+        reviewer=FailingReviewer(),
         event_logger=events,
     )
 
@@ -513,4 +693,27 @@ def test_resilient_processor_records_deepseek_failure_and_fallback() -> None:
         "stage.fallback",
     ]
     assert events.items[1]["details"]["retry_count"] == 0
-    assert events.items[2]["details"]["reason"] == "deepseek_unavailable"
+    assert events.items[2]["details"]["reason"] == "deepseek_review_failed"
+
+
+def test_reviewed_processor_does_not_send_fa_kara_to_deepseek() -> None:
+    processor_module = importlib.import_module("app.lyrics.processor")
+
+    class RecordingReviewer:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def review(self, document: LyricDocument) -> LyricDocument:
+            self.calls += 1
+            return replace(document, provider="local+deepseek")
+
+    reviewer = RecordingReviewer()
+    processor = processor_module.ReviewedLyricProcessor(
+        base=processor_module.LocalJapaneseLyricProcessor(),
+        reviewer=reviewer,
+    )
+
+    document = processor.process("{今日|きょう}")
+
+    assert reviewer.calls == 0
+    assert document.provider == "local"

--- a/backend/tests/test_numeric_reading.py
+++ b/backend/tests/test_numeric_reading.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+from app.lyrics.numeric_reading import integer_reading
+
+
+@pytest.mark.parametrize(
+    ("digits", "reading"),
+    [
+        ("300", "さんびゃく"),
+        ("600", "ろっぴゃく"),
+        ("800", "はっぴゃく"),
+        ("3000", "さんぜん"),
+        ("8000", "はっせん"),
+        ("10000", "いちまん"),
+        ("100000000", "いちおく"),
+        ("1000000000000", "いっちょう"),
+    ],
+)
+def test_integer_reading_applies_large_number_sound_changes(
+    digits: str,
+    reading: str,
+) -> None:
+    assert integer_reading(digits) == reading


### PR DESCRIPTION
## 无 AI 的省流

此部分为人撰写的，不是 AI。

简而言之，我本来是发现有连浊（なき+こえ=なきごえ）的情况它不能识别，于是跟 Codex 进行了探讨。我本来的主意是单纯把连浊的机制加上去，结果后来发现这个语法问题很复杂。

但后来发现，其实在后端的 Janome 工具里已经提供了正确的读音。我们继续检查就会发现，Janome 其实能直接从词典给出很多词的正确读音，而工具却没有用，而是用 pykakasi 去做一对一的表面转换，而且还是一个词一个词拆开来转换的，自然无法照顾到词之间的连浊和其他联用是特殊读音等。

以及在另外一条路上，DeepSeek API 是直接把所有东西都喂给它。但从考虑用户用量的角度来说，其实只有汉字以及英语这些会有明显的问题，至于假名显然是没有问题的。

因此做如下开发。

**声明：代码编写全部由 GPT** ~~辅助~~ **完成，但结果由我审阅过。此功能是真正的需求，遇到的也是真正的问题，希望能帮到这个项目！**

> 以及提交重新调整过，所以会显得几分钟内连 commit 3 次，实际上并不是的

---

## 背景

这个问题最初是在检查一首真实日语歌曲的注音结果时发现的。

歌词中的「泣き声」应读作「なきごえ」，但本地处理结果出现了「なきこえ」。继续检查「歌声」「歌姫」「無き声」「君」等词后，我们发现这不是缺少个别词语特例，而是现有读音处理流程的职责划分有问题。

以「泣き声」为例，Janome 已经能够从词典中给出正确读音「ナキゴエ」，但处理器没有优先使用这个结果，而是再次用 pykakasi 根据表面文字转换，最终得到「なきこえ」。pykakasi 适合进行假名转换和未知表记兜底，但不适合覆盖 Janome 已经提供的词典读音。

DeepSeek 的原有职责也过重。它会从原始歌词重新生成整行文字、读音和全部 token，而不是检查本地结果。这产生了几个问题：

- 本地处理和 DeepSeek 分别维护一套完整的歌词生成逻辑；
- DeepSeek 可以改变歌词表面文字和 token 结构；
- 提示词要求它判断数字和英文的“实际唱法”，但请求中并没有音频；
- DeepSeek 调用失败后才启用本地处理，使本地链路长期停留在备用方案，而不是完整、可独立运行的主流程。

调查过程中还发现，部分词会被拆成多个 token。例如「無き声」可能拆成「無」「き」「声」。原有实验比较方式只能查找单个 token，可能产生空结果。为避免围绕错误的实验结论修改代码，本次也修正了比较工具，使其能够跨连续 token 重建词语及读音。

## 本次修改

本次将歌词读音处理调整为“本地完整生成，DeepSeek 可选审阅”。

本地处理顺序现在是：

1. 保留用户明确提供的注音；
2. 优先使用 Janome 的词典读音和词性信息；
3. 对 Janome 无法确定的常见数字、日期和助数词使用本地规则；
4. 使用 alkana 生成常见英文词候选，未知缩写按字母生成候选；
5. 使用 pykakasi 完成片假名到平假名的转换，并处理剩余未知日文表记。

这样，即使没有配置 DeepSeek API，本地处理器也能独立生成结构完整、可供人工确认和后续对齐使用的歌词文档。

### 数字读音

新增了本地日语数字处理模块，支持常见且具有确定规则的情况，包括：

- 整数以及万、億、兆；
- 百、千位常见音变；
- 月、日、時、時半；
- 人、分、泊、つ、丁目等助数词；
- 数字后接普通外来单位。

例如：

- `80億分の1` → `はちじゅうおくぶんのいち`
- `100分` → `ひゃっぷん`
- `3泊4日` → `さんぱくよっか`
- `8月15日` → `はちがつじゅうごにち`
- `午後12時半` → `ごごじゅうにじはん`

对于 `321`、`50:50`、`12345ire`、`1LDK` 等无法仅凭表记确定实际唱法的内容，系统仍只生成可编辑候选，并保留原始表记供用户确认。本次没有尝试用通用规则替作品决定特殊读法。

### DeepSeek 审阅

DeepSeek 不再重新生成整份歌词，而是在本地文档生成后接收原文及 token 列表，只返回需要依赖上下文修正的连续 token 范围。

例如，本地结果将「無き声」拆成：

```text
無 / な
き / き
声 / こえ
```

DeepSeek 可以针对这个范围建议修正为「なきごえ」，但不能重新输出整行歌词，也不能修改其他 token。

所有修正在应用前都会统一验证：

- 行号和 token 范围必须有效；
- 多个修正范围不能重叠；
- surface 和当前读音必须能从原 token 精确重建；
- 不能修改数字、英文或显式发音信息；
- 修正读音必须是有效平假名；
- 原歌词中的假名和空格必须保持在原位置；
- 汉字读音不能夹带未对应歌词表面的空格；
- 修正后不能产生空读音 token；
- 修正后的 token 必须能够重新构成原 surface 和新 reading。

任意一项修正非法时，整次 DeepSeek 审阅结果都会作废，不会部分写入。系统直接保留已经生成的本地文档，也不会重复执行本地处理。

未配置 API Key 时只使用本地处理。配置 API Key 且审阅成功时，provider 为 `local+deepseek`；调用或校验失败时仍为 `local`，并记录 `deepseek_review_failed:<ExceptionType>`。

含有 FA-Kara 手动注音的歌词继续全部走本地处理，不发送给 DeepSeek。

## 验证

跨 token 比较已经确认能够实际命中：歌声 / 泣き声 / 歌姫 / 無き声 / 君 这些复杂词汇。

当前验证结果：

- 完整后端测试：303 个通过；
- 注音与流水线核心测试：88 个通过；
- 实验测试：7 个通过；
- DeepSeek 审阅使用受控 JSON 响应测试正常修正、空修正、失败回退和非法结果拒绝。